### PR TITLE
LoongArch port

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,7 @@ noinst_HEADERS = src/aarch64/ffitarget.h src/aarch64/internal.h		\
 	src/sparc/internal.h src/tile/ffitarget.h src/vax/ffitarget.h	\
 	src/x86/ffitarget.h src/x86/internal.h src/x86/internal64.h	\
 	src/x86/asmnames.h src/xtensa/ffitarget.h src/dlmalloc.c	\
-	src/kvx/ffitarget.h
+	src/kvx/ffitarget.h src/loongarch/ffitarget.h
 
 EXTRA_libffi_la_SOURCES = src/aarch64/ffi.c src/aarch64/sysv.S		\
 	src/aarch64/win64_armasm.S src/alpha/ffi.c src/alpha/osf.S	\
@@ -93,7 +93,7 @@ EXTRA_libffi_la_SOURCES = src/aarch64/ffi.c src/aarch64/sysv.S		\
 	src/x86/ffiw64.c src/x86/win64.S src/x86/ffi64.c		\
 	src/x86/unix64.S src/x86/sysv_intel.S src/x86/win64_intel.S	\
 	src/xtensa/ffi.c src/xtensa/sysv.S src/kvx/ffi.c		\
-	src/kvx/sysv.S
+	src/kvx/sysv.S src/loongarch/ffi.c src/loongarch/sysv.S
 
 TARGET_OBJ = @TARGET_OBJ@
 libffi_la_LIBADD = $(TARGET_OBJ)

--- a/config.guess
+++ b/config.guess
@@ -985,6 +985,9 @@ EOF
     k1om:Linux:*:*)
 	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
 	exit ;;
+    loongarch64:Linux:*:* | loongarch64:Linux:*:* | loongarchx32:Linux:*:*)
+	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+	exit ;;
     m32r*:Linux:*:*)
 	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
 	exit ;;

--- a/config.sub
+++ b/config.sub
@@ -1185,6 +1185,7 @@ case $cpu-$vendor in
 			| k1om \
 			| le32 | le64 \
 			| lm32 \
+			| loongarch32 | loongarch64 | loongarchx32 \
 			| m32c | m32r | m32rle \
 			| m5200 | m68000 | m680[012346]0 | m68360 | m683?2 | m68k \
 			| m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x \

--- a/configure.host
+++ b/configure.host
@@ -140,6 +140,11 @@ case "${host}" in
 	SOURCES="ffi.c sysv.S"
 	;;
 
+  loongarch64-*-*)
+	TARGET=LOONGARCH64; TARGETDIR=loongarch
+	SOURCES="ffi.c sysv.S"
+	;;
+
   m32r*-*-*)
 	TARGET=M32R; TARGETDIR=m32r
 	SOURCES="ffi.c sysv.S"

--- a/src/loongarch/ffi.c
+++ b/src/loongarch/ffi.c
@@ -1,0 +1,485 @@
+/* -----------------------------------------------------------------------
+   ffi.c - Copyright (c) 2015 Michael Knyszek <mknyszek@berkeley.edu>
+                         2015 Andrew Waterman <waterman@cs.berkeley.edu>
+                         2018 Stef O'Rear <sorear2@gmail.com>
+                         2021 Xi Ruoyao <xry111@mengyan1223.wang>
+   Based on MIPS N32/64 and RISC-V port
+
+   LoongArch Foreign Function Interface
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#include <ffi.h>
+#include <ffi_common.h>
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#if _LOONGARCH_SIM == _ABILP64
+#define STKALIGN 16
+#elif _LOONGARCH_SIM == _ABILP32
+#define STKALIGN 8
+#else
+#error "Don't know LoongArch ABIs other than LP64 or LP32 now."
+#endif
+
+/* Now we don't have soft-float ABIs defined.  */
+#define ABI_FLEN 64
+#define ABI_FLOAT double
+
+#define NARGREG 8
+#define MAXCOPYARG (2 * sizeof(double))
+
+typedef struct call_context
+{
+#if ABI_FLEN
+    ABI_FLOAT fa[8];
+#endif
+    size_t a[8];
+    /* used by the assembly code to in-place construct its own stack frame */
+    char frame[16];
+} call_context;
+
+typedef struct call_builder
+{
+    call_context *aregs;
+    int used_integer;
+    int used_float;
+    size_t *used_stack;
+} call_builder;
+
+/* integer (not pointer) less than ABI XLEN */
+/* FFI_TYPE_INT does not appear to be used */
+#if __SIZEOF_POINTER__ == 8
+#define IS_INT(type) ((type) >= FFI_TYPE_UINT8 && (type) <= FFI_TYPE_SINT64)
+#else
+#define IS_INT(type) ((type) >= FFI_TYPE_UINT8 && (type) <= FFI_TYPE_SINT32)
+#endif
+
+#if ABI_FLEN
+typedef struct {
+    char as_elements, type1, offset2, type2;
+} float_struct_info;
+
+#if ABI_FLEN >= 64
+#define IS_FLOAT(type) ((type) >= FFI_TYPE_FLOAT && (type) <= FFI_TYPE_DOUBLE)
+#else
+#define IS_FLOAT(type) ((type) == FFI_TYPE_FLOAT)
+#endif
+
+static ffi_type **flatten_struct(ffi_type *in, ffi_type **out, ffi_type **out_end) {
+    int i;
+    if (out == out_end) return out;
+    if (in->type != FFI_TYPE_STRUCT) {
+        *(out++) = in;
+    } else {
+        for (i = 0; in->elements[i]; i++)
+            out = flatten_struct(in->elements[i], out, out_end);
+    }
+    return out;
+}
+
+/* Structs with at most two fields after flattening, one of which is of
+   floating point type, are passed in multiple registers if sufficient
+   registers are available. */
+static float_struct_info struct_passed_as_elements(call_builder *cb, ffi_type *top) {
+    float_struct_info ret = {0, 0, 0, 0};
+    ffi_type *fields[3];
+    int num_floats, num_ints;
+    int num_fields = flatten_struct(top, fields, fields + 3) - fields;
+
+    if (num_fields == 1) {
+        if (IS_FLOAT(fields[0]->type)) {
+            ret.as_elements = 1;
+            ret.type1 = fields[0]->type;
+        }
+    } else if (num_fields == 2) {
+        num_floats = IS_FLOAT(fields[0]->type) + IS_FLOAT(fields[1]->type);
+        num_ints = IS_INT(fields[0]->type) + IS_INT(fields[1]->type);
+        if (num_floats == 0 || num_floats + num_ints != 2)
+            return ret;
+        if (cb->used_float + num_floats > NARGREG || cb->used_integer + (2 - num_floats) > NARGREG)
+            return ret;
+        if (!IS_FLOAT(fields[0]->type) && !IS_FLOAT(fields[1]->type))
+            return ret;
+
+        ret.type1 = fields[0]->type;
+        ret.type2 = fields[1]->type;
+        ret.offset2 = FFI_ALIGN(fields[0]->size, fields[1]->alignment);
+        ret.as_elements = 1;
+    }
+
+    return ret;
+}
+#endif
+
+/* allocates a single register, float register, or XLEN-sized stack slot to a datum */
+static void marshal_atom(call_builder *cb, int type, void *data) {
+    size_t value = 0;
+    switch (type) {
+        case FFI_TYPE_UINT8: value = *(uint8_t *)data; break;
+        case FFI_TYPE_SINT8: value = *(int8_t *)data; break;
+        case FFI_TYPE_UINT16: value = *(uint16_t *)data; break;
+        case FFI_TYPE_SINT16: value = *(int16_t *)data; break;
+        /* 32-bit quantities are always sign-extended in the ABI */
+        case FFI_TYPE_UINT32: value = *(int32_t *)data; break;
+        case FFI_TYPE_SINT32: value = *(int32_t *)data; break;
+#if __SIZEOF_POINTER__ == 8
+        case FFI_TYPE_UINT64: value = *(uint64_t *)data; break;
+        case FFI_TYPE_SINT64: value = *(int64_t *)data; break;
+#endif
+        case FFI_TYPE_POINTER: value = *(size_t *)data; break;
+
+        /* float values may be recoded in an implementation-defined way
+           by hardware conforming to 2.1 or earlier, so use asm to
+           reinterpret floats as doubles */
+#if ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(float *)data));
+            return;
+#endif
+#if ABI_FLEN >= 64
+        case FFI_TYPE_DOUBLE:
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(double *)data));
+            return;
+#endif
+        default: FFI_ASSERT(0); break;
+    }
+
+    if (cb->used_integer == NARGREG) {
+        *cb->used_stack++ = value;
+    } else {
+        cb->aregs->a[cb->used_integer++] = value;
+    }
+}
+
+static void unmarshal_atom(call_builder *cb, int type, void *data) {
+    size_t value;
+    switch (type) {
+#if ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            return;
+#endif
+#if ABI_FLEN >= 64
+        case FFI_TYPE_DOUBLE:
+            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            return;
+#endif
+    }
+
+    if (cb->used_integer == NARGREG) {
+        value = *cb->used_stack++;
+    } else {
+        value = cb->aregs->a[cb->used_integer++];
+    }
+
+    switch (type) {
+        case FFI_TYPE_UINT8: *(uint8_t *)data = value; break;
+        case FFI_TYPE_SINT8: *(uint8_t *)data = value; break;
+        case FFI_TYPE_UINT16: *(uint16_t *)data = value; break;
+        case FFI_TYPE_SINT16: *(uint16_t *)data = value; break;
+        case FFI_TYPE_UINT32: *(uint32_t *)data = value; break;
+        case FFI_TYPE_SINT32: *(uint32_t *)data = value; break;
+#if __SIZEOF_POINTER__ == 8
+        case FFI_TYPE_UINT64: *(uint64_t *)data = value; break;
+        case FFI_TYPE_SINT64: *(uint64_t *)data = value; break;
+#endif
+        case FFI_TYPE_POINTER: *(size_t *)data = value; break;
+        default: FFI_ASSERT(0); break;
+    }
+}
+
+/* adds an argument to a call, or a not by reference return value */
+static void marshal(call_builder *cb, ffi_type *type, int var, void *data) {
+    size_t realign[2];
+
+#if ABI_FLEN
+    if (!var && type->type == FFI_TYPE_STRUCT) {
+        float_struct_info fsi = struct_passed_as_elements(cb, type);
+        if (fsi.as_elements) {
+            marshal_atom(cb, fsi.type1, data);
+            if (fsi.offset2)
+                marshal_atom(cb, fsi.type2, ((char*)data) + fsi.offset2);
+            return;
+        }
+    }
+
+    if (!var && cb->used_float < NARGREG && IS_FLOAT(type->type)) {
+        marshal_atom(cb, type->type, data);
+        return;
+    }
+#endif
+
+    if (type->size > 2 * __SIZEOF_POINTER__) {
+        /* pass by reference */
+        marshal_atom(cb, FFI_TYPE_POINTER, &data);
+    } else if (IS_INT(type->type) || type->type == FFI_TYPE_POINTER) {
+        marshal_atom(cb, type->type, data);
+    } else {
+        /* overlong integers, soft-float floats, and structs without special
+           float handling are treated identically from this point on */
+
+        /* variadics are aligned even in registers */
+        if (type->alignment > __SIZEOF_POINTER__) {
+            if (var)
+                cb->used_integer = FFI_ALIGN(cb->used_integer, 2);
+            cb->used_stack = (size_t *)FFI_ALIGN(cb->used_stack, 2*__SIZEOF_POINTER__);
+        }
+
+        memcpy(realign, data, type->size);
+        if (type->size > 0)
+            marshal_atom(cb, FFI_TYPE_POINTER, realign);
+        if (type->size > __SIZEOF_POINTER__)
+            marshal_atom(cb, FFI_TYPE_POINTER, realign + 1);
+    }
+}
+
+/* for arguments passed by reference returns the pointer, otherwise the arg is copied (up to MAXCOPYARG bytes) */
+static void *unmarshal(call_builder *cb, ffi_type *type, int var, void *data) {
+    size_t realign[2];
+    void *pointer;
+
+#if ABI_FLEN
+    if (!var && type->type == FFI_TYPE_STRUCT) {
+        float_struct_info fsi = struct_passed_as_elements(cb, type);
+        if (fsi.as_elements) {
+            unmarshal_atom(cb, fsi.type1, data);
+            if (fsi.offset2)
+                unmarshal_atom(cb, fsi.type2, ((char*)data) + fsi.offset2);
+            return data;
+        }
+    }
+
+    if (!var && cb->used_float < NARGREG && IS_FLOAT(type->type)) {
+        unmarshal_atom(cb, type->type, data);
+        return data;
+    }
+#endif
+
+    if (type->size > 2 * __SIZEOF_POINTER__) {
+        /* pass by reference */
+        unmarshal_atom(cb, FFI_TYPE_POINTER, (char*)&pointer);
+        return pointer;
+    } else if (IS_INT(type->type) || type->type == FFI_TYPE_POINTER) {
+        unmarshal_atom(cb, type->type, data);
+        return data;
+    } else {
+        /* overlong integers, soft-float floats, and structs without special
+           float handling are treated identically from this point on */
+
+        /* variadics are aligned even in registers */
+        if (type->alignment > __SIZEOF_POINTER__) {
+            if (var)
+                cb->used_integer = FFI_ALIGN(cb->used_integer, 2);
+            cb->used_stack = (size_t *)FFI_ALIGN(cb->used_stack, 2*__SIZEOF_POINTER__);
+        }
+
+        if (type->size > 0)
+            unmarshal_atom(cb, FFI_TYPE_POINTER, realign);
+        if (type->size > __SIZEOF_POINTER__)
+            unmarshal_atom(cb, FFI_TYPE_POINTER, realign + 1);
+        memcpy(data, realign, type->size);
+        return data;
+    }
+}
+
+static int passed_by_ref(call_builder *cb, ffi_type *type, int var) {
+#if ABI_FLEN
+    if (!var && type->type == FFI_TYPE_STRUCT) {
+        float_struct_info fsi = struct_passed_as_elements(cb, type);
+        if (fsi.as_elements) return 0;
+    }
+#endif
+
+    return type->size > 2 * __SIZEOF_POINTER__;
+}
+
+/* Perform machine dependent cif processing */
+ffi_status ffi_prep_cif_machdep(ffi_cif *cif) {
+    cif->loongarch_nfixedargs = cif->nargs;
+    return FFI_OK;
+}
+
+/* Perform machine dependent cif processing when we have a variadic function */
+
+ffi_status ffi_prep_cif_machdep_var(ffi_cif *cif, unsigned int nfixedargs, unsigned int ntotalargs) {
+    cif->loongarch_nfixedargs = nfixedargs;
+    return FFI_OK;
+}
+
+/* Low level routine for calling functions */
+extern void ffi_call_asm (void *stack, struct call_context *regs,
+			  void (*fn) (void), void *closure) FFI_HIDDEN;
+
+static void
+ffi_call_int (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue,
+	      void *closure)
+{
+    /* this is a conservative estimate, assuming a complex return value and
+       that all remaining arguments are long long / __int128 */
+    size_t arg_bytes = cif->nargs <= 3 ? 0 :
+        FFI_ALIGN(2 * sizeof(size_t) * (cif->nargs - 3), STKALIGN);
+    size_t rval_bytes = 0;
+    if (rvalue == NULL && cif->rtype->size > 2*__SIZEOF_POINTER__)
+        rval_bytes = FFI_ALIGN(cif->rtype->size, STKALIGN);
+    size_t alloc_size = arg_bytes + rval_bytes + sizeof(call_context);
+
+    /* the assembly code will deallocate all stack data at lower addresses
+       than the argument region, so we need to allocate the frame and the
+       return value after the arguments in a single allocation */
+    size_t alloc_base;
+    /* Argument region must be 8 or 16-byte aligned */
+    if (_Alignof(max_align_t) >= STKALIGN) {
+        /* since sizeof long double is normally 16, the compiler will
+           guarantee alloca alignment to at least that much */
+        alloc_base = (size_t)alloca(alloc_size);
+    } else {
+        alloc_base = FFI_ALIGN(alloca(alloc_size + STKALIGN - 1), STKALIGN);
+    }
+
+    if (rval_bytes)
+        rvalue = (void*)(alloc_base + arg_bytes);
+
+    call_builder cb;
+    cb.used_float = cb.used_integer = 0;
+    cb.aregs = (call_context*)(alloc_base + arg_bytes + rval_bytes);
+    cb.used_stack = (void*)alloc_base;
+
+    int return_by_ref = passed_by_ref(&cb, cif->rtype, 0);
+    if (return_by_ref)
+        marshal(&cb, &ffi_type_pointer, 0, &rvalue);
+
+    int i;
+    for (i = 0; i < cif->nargs; i++)
+        marshal(&cb, cif->arg_types[i], i >= cif->loongarch_nfixedargs, avalue[i]);
+
+    ffi_call_asm ((void *) alloc_base, cb.aregs, fn, closure);
+
+    cb.used_float = cb.used_integer = 0;
+    if (!return_by_ref && rvalue)
+        unmarshal(&cb, cif->rtype, 0, rvalue);
+}
+
+void
+ffi_call (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue)
+{
+  ffi_call_int(cif, fn, rvalue, avalue, NULL);
+}
+
+void
+ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue,
+	     void **avalue, void *closure)
+{
+  ffi_call_int(cif, fn, rvalue, avalue, closure);
+}
+
+extern void ffi_closure_asm(void) FFI_HIDDEN;
+
+ffi_status ffi_prep_closure_loc(ffi_closure *closure, ffi_cif *cif, void (*fun)(ffi_cif*,void*,void**,void*), void *user_data, void *codeloc)
+{
+    uint32_t *tramp = (uint32_t *) &closure->tramp[0];
+    uint64_t fn = (uint64_t) (uintptr_t) ffi_closure_asm;
+
+    if (cif->abi <= FFI_FIRST_ABI || cif->abi >= FFI_LAST_ABI)
+        return FFI_BAD_ABI;
+
+    /* we will call ffi_closure_inner with codeloc, not closure, but as long
+       as the memory is readable it should work */
+
+    tramp[0] = 0x1c00000d; /* pcaddu12i $t1, 0        */
+#if __SIZEOF_POINTER__ == 8
+    tramp[1] = 0x28c041ac; /* ld.d      $t0, $t1, 16  */
+#else
+    tramp[1] = 0x288041ac; /* ld.w      $t0, $t1, 16  */
+#endif
+    tramp[2] = 0x4c000180; /* jirl      $zero, $t0, 0 */
+    tramp[3] = 0x03400000; /* nop                     */
+    tramp[4] = fn;
+    tramp[5] = fn >> 32;
+
+    closure->cif = cif;
+    closure->fun = fun;
+    closure->user_data = user_data;
+
+    __builtin___clear_cache(codeloc, codeloc + FFI_TRAMPOLINE_SIZE);
+
+    return FFI_OK;
+}
+
+extern void ffi_go_closure_asm (void) FFI_HIDDEN;
+
+ffi_status
+ffi_prep_go_closure (ffi_go_closure *closure, ffi_cif *cif,
+		     void (*fun) (ffi_cif *, void *, void **, void *))
+{
+  if (cif->abi <= FFI_FIRST_ABI || cif->abi >= FFI_LAST_ABI)
+    return FFI_BAD_ABI;
+
+  closure->tramp = (void *) ffi_go_closure_asm;
+  closure->cif = cif;
+  closure->fun = fun;
+
+  return FFI_OK;
+}
+
+/* Called by the assembly code with aregs pointing to saved argument registers
+   and stack pointing to the stacked arguments.  Return values passed in
+   registers will be reloaded from aregs. */
+void FFI_HIDDEN
+ffi_closure_inner (ffi_cif *cif,
+		   void (*fun) (ffi_cif *, void *, void **, void *),
+		   void *user_data,
+		   size_t *stack, call_context *aregs)
+{
+    void **avalue = alloca(cif->nargs * sizeof(void*));
+    /* storage for arguments which will be copied by unmarshal().  We could
+       theoretically avoid the copies in many cases and use at most 128 bytes
+       of memory, but allocating disjoint storage for each argument is
+       simpler. */
+    char *astorage = alloca(cif->nargs * MAXCOPYARG);
+    void *rvalue;
+    call_builder cb;
+    int return_by_ref;
+    int i;
+
+    cb.aregs = aregs;
+    cb.used_integer = cb.used_float = 0;
+    cb.used_stack = stack;
+
+    return_by_ref = passed_by_ref(&cb, cif->rtype, 0);
+    if (return_by_ref)
+        unmarshal(&cb, &ffi_type_pointer, 0, &rvalue);
+    else
+        rvalue = alloca(cif->rtype->size);
+
+    for (i = 0; i < cif->nargs; i++)
+        avalue[i] = unmarshal(&cb, cif->arg_types[i],
+            i >= cif->loongarch_nfixedargs, astorage + i*MAXCOPYARG);
+
+    fun (cif, rvalue, avalue, user_data);
+
+    if (!return_by_ref && cif->rtype->type != FFI_TYPE_VOID) {
+        cb.used_integer = cb.used_float = 0;
+        marshal(&cb, cif->rtype, 0, rvalue);
+    }
+}

--- a/src/loongarch/ffitarget.h
+++ b/src/loongarch/ffitarget.h
@@ -1,0 +1,64 @@
+/* -----------------------------------------------------------------*-C-*-
+   ffitarget.h - 2014 Michael Knyszek
+                 2021 Xi Ruoyao
+
+   Target configuration macros for LoongArch.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+
+#ifndef LIBFFI_TARGET_H
+#define LIBFFI_TARGET_H
+
+#ifndef LIBFFI_H
+#error "Please do not include ffitarget.h directly into your source.  Use ffi.h instead."
+#endif
+
+#ifndef _LOONGARCH_SIM
+#error "libffi was configured for a LoongArch target but this does not appear to be a LoongArch compiler."
+#endif
+
+#ifndef LIBFFI_ASM
+
+typedef unsigned long ffi_arg;
+typedef   signed long ffi_sarg;
+typedef enum ffi_abi {
+    FFI_FIRST_ABI = 0,
+    FFI_SYSV,
+    FFI_LAST_ABI,
+
+    FFI_DEFAULT_ABI = FFI_SYSV
+} ffi_abi;
+
+#endif /* LIBFFI_ASM */
+
+/* ---- Definitions for closures ----------------------------------------- */
+
+#define FFI_CLOSURES 1
+#define FFI_GO_CLOSURES 1
+#define FFI_TRAMPOLINE_SIZE 24
+#define FFI_NATIVE_RAW_API 0
+#define FFI_EXTRA_CIF_FIELDS unsigned loongarch_nfixedargs; unsigned loongarch_unused;
+#define FFI_TARGET_SPECIFIC_VARIADIC
+
+#endif
+

--- a/src/loongarch/sysv.S
+++ b/src/loongarch/sysv.S
@@ -1,0 +1,287 @@
+/* -----------------------------------------------------------------------
+   ffi.c - Copyright (c) 2015 Michael Knyszek <mknyszek@berkeley.edu>
+                         2015 Andrew Waterman <waterman@cs.berkeley.edu>
+                         2018 Stef O'Rear <sorear2@gmail.com>
+                         2021 Xi Ruoyao <xry111@mengyan1223.wang>
+
+   LoongArch Foreign Function Interface
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   ``Software''), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ----------------------------------------------------------------------- */
+
+#define LIBFFI_ASM
+#include <fficonfig.h>
+#include <ffi.h>
+
+/* Define aliases so that we can handle all ABIs uniformly */
+
+#if _LOONGARCH_SIM == _ABILP64
+#define PTRS 8
+#define LARG ld.d
+#define SARG st.d
+#define ADDI addi.d
+#elif _LOONGARCH_SIM == _ABILP32
+#define PTRS 4
+#define LARG ld.w
+#define SARG st.w
+#define ADDI addi.w
+#else
+#error "Unknown LoongArch ABI"
+#endif
+
+#define FLTS 8
+#define FLARG fld.d
+#define FSARG fst.d
+
+    .text
+    .globl  ffi_call_asm
+    .type   ffi_call_asm, @function
+    .hidden ffi_call_asm
+/*
+  struct call_context {
+      floatreg fa[8];
+      intreg a[8];
+      intreg save_fp, save_ra;
+  }
+  void ffi_call_asm (size_t *stackargs, struct call_context *regargs,
+                     void (*fn) (void), void *closure);
+*/
+
+#define FRAME_LEN (8 * FLTS + 10 * PTRS)
+
+ffi_call_asm:
+    .cfi_startproc
+
+    /*
+      We are NOT going to set up an ordinary stack frame.  In order to pass
+      the stacked args to the called function, we adjust our stack pointer to
+      a0, which is in the _caller's_ alloca area.  We establish our own stack
+      frame at the end of the call_context.
+
+      Anything below the arguments will be freed at this point, although we
+      preserve the call_context so that it can be read back in the caller.
+    */
+
+    .cfi_def_cfa 5, FRAME_LEN # interim CFA based on a1
+    SARG    $fp, $a1, FRAME_LEN - 2*PTRS
+    .cfi_offset 22, -2*PTRS
+    SARG    $ra, $a1, FRAME_LEN - 1*PTRS
+    .cfi_offset 1, -1*PTRS
+
+    ADDI    $fp, $a1, FRAME_LEN
+    ADDI    $sp, $a0, 0
+    .cfi_def_cfa 22, 0 # our frame is fully set up
+
+    # Load arguments
+    ADDI    $t0, $a2, 0
+    ADDI    $t1, $a3, 0 # used by ffi_go_closure_asm
+
+#if FLTS
+    FLARG   $fa0, $fp, -FRAME_LEN+0*FLTS
+    FLARG   $fa1, $fp, -FRAME_LEN+1*FLTS
+    FLARG   $fa2, $fp, -FRAME_LEN+2*FLTS
+    FLARG   $fa3, $fp, -FRAME_LEN+3*FLTS
+    FLARG   $fa4, $fp, -FRAME_LEN+4*FLTS
+    FLARG   $fa5, $fp, -FRAME_LEN+5*FLTS
+    FLARG   $fa6, $fp, -FRAME_LEN+6*FLTS
+    FLARG   $fa7, $fp, -FRAME_LEN+7*FLTS
+#endif
+
+    LARG    $a0, $fp, -FRAME_LEN+8*FLTS+0*PTRS
+    LARG    $a1, $fp, -FRAME_LEN+8*FLTS+1*PTRS
+    LARG    $a2, $fp, -FRAME_LEN+8*FLTS+2*PTRS
+    LARG    $a3, $fp, -FRAME_LEN+8*FLTS+3*PTRS
+    LARG    $a4, $fp, -FRAME_LEN+8*FLTS+4*PTRS
+    LARG    $a5, $fp, -FRAME_LEN+8*FLTS+5*PTRS
+    LARG    $a6, $fp, -FRAME_LEN+8*FLTS+6*PTRS
+    LARG    $a7, $fp, -FRAME_LEN+8*FLTS+7*PTRS
+
+    /* Call */
+    jirl    $ra, $t0, 0
+
+    /* Save return values - only a0/a1 (fa0/fa1) are used */
+#if FLTS
+    FSARG   $fa0, $fp, -FRAME_LEN+0*FLTS
+    FSARG   $fa1, $fp, -FRAME_LEN+1*FLTS
+#endif
+
+    SARG    $a0, $fp, -FRAME_LEN+8*FLTS+0*PTRS
+    SARG    $a1, $fp, -FRAME_LEN+8*FLTS+1*PTRS
+
+    /* Restore and return */
+    ADDI    $sp, $fp, -FRAME_LEN
+    .cfi_def_cfa 3, FRAME_LEN
+    LARG    $ra, $fp, -1*PTRS
+    .cfi_restore 1
+    LARG    $fp, $fp, -2*PTRS
+    .cfi_restore 22
+    jirl    $zero, $ra, 0
+    .cfi_endproc
+    .size   ffi_call_asm, .-ffi_call_asm
+
+
+/*
+  ffi_closure_asm. Expects address of the passed-in ffi_closure in t1.
+  void ffi_closure_inner (ffi_cif *cif,
+		          void (*fun) (ffi_cif *, void *, void **, void *),
+		          void *user_data,
+		          size_t *stackargs, struct call_context *regargs)
+*/
+
+    .globl ffi_closure_asm
+    .hidden ffi_closure_asm
+    .type ffi_closure_asm, @function
+ffi_closure_asm:
+    .cfi_startproc
+
+    ADDI    $sp,  $sp, -FRAME_LEN
+    .cfi_def_cfa_offset FRAME_LEN
+
+    /* make a frame */
+    SARG    $fp, $sp, FRAME_LEN - 2*PTRS
+    .cfi_offset 22, -2*PTRS
+    SARG    $ra, $sp, FRAME_LEN - 1*PTRS
+    .cfi_offset 1, -1*PTRS
+    ADDI    $fp, $sp, FRAME_LEN
+
+    /* save arguments */
+#if FLTS
+    FSARG   $fa0, $sp, 0*FLTS
+    FSARG   $fa1, $sp, 1*FLTS
+    FSARG   $fa2, $sp, 2*FLTS
+    FSARG   $fa3, $sp, 3*FLTS
+    FSARG   $fa4, $sp, 4*FLTS
+    FSARG   $fa5, $sp, 5*FLTS
+    FSARG   $fa6, $sp, 6*FLTS
+    FSARG   $fa7, $sp, 7*FLTS
+#endif
+
+    SARG    $a0, $sp, 8*FLTS+0*PTRS
+    SARG    $a1, $sp, 8*FLTS+1*PTRS
+    SARG    $a2, $sp, 8*FLTS+2*PTRS
+    SARG    $a3, $sp, 8*FLTS+3*PTRS
+    SARG    $a4, $sp, 8*FLTS+4*PTRS
+    SARG    $a5, $sp, 8*FLTS+5*PTRS
+    SARG    $a6, $sp, 8*FLTS+6*PTRS
+    SARG    $a7, $sp, 8*FLTS+7*PTRS
+
+    /* enter C */
+    LARG    $a0, $t1, FFI_TRAMPOLINE_SIZE+0*PTRS
+    LARG    $a1, $t1, FFI_TRAMPOLINE_SIZE+1*PTRS
+    LARG    $a2, $t1, FFI_TRAMPOLINE_SIZE+2*PTRS
+    ADDI    $a3, $sp, FRAME_LEN
+    ADDI    $a4, $sp, 0
+
+    bl      ffi_closure_inner
+
+    /* return values */
+#if FLTS
+    FLARG   $fa0, $sp, 0*FLTS
+    FLARG   $fa1, $sp, 1*FLTS
+#endif
+
+    LARG    $a0, $sp, 8*FLTS+0*PTRS
+    LARG    $a1, $sp, 8*FLTS+1*PTRS
+
+    /* restore and return */
+    LARG    $ra, $sp, FRAME_LEN-1*PTRS
+    .cfi_restore 1
+    LARG    $fp, $sp, FRAME_LEN-2*PTRS
+    .cfi_restore 22
+    ADDI    $sp, $sp, FRAME_LEN
+    .cfi_def_cfa_offset 0
+    jirl    $zero, $ra, 0
+    .cfi_endproc
+    .size ffi_closure_asm, .-ffi_closure_asm
+
+/*
+  ffi_go_closure_asm.  Expects address of the passed-in ffi_go_closure in t1.
+  void ffi_closure_inner (ffi_cif *cif,
+		          void (*fun) (ffi_cif *, void *, void **, void *),
+		          void *user_data,
+		          size_t *stackargs, struct call_context *regargs)
+*/
+
+    .globl ffi_go_closure_asm
+    .hidden ffi_go_closure_asm
+    .type ffi_go_closure_asm, @function
+ffi_go_closure_asm:
+    .cfi_startproc
+
+    ADDI    $sp,  $sp, -FRAME_LEN
+    .cfi_def_cfa_offset FRAME_LEN
+
+    /* make a frame */
+    SARG    $fp, $sp, FRAME_LEN - 2*PTRS
+    .cfi_offset 22, -2*PTRS
+    SARG    $ra, $sp, FRAME_LEN - 1*PTRS
+    .cfi_offset 1, -1*PTRS
+    ADDI    $fp, $sp, FRAME_LEN
+
+    /* save arguments */
+#if FLTS
+    FSARG   $fa0, $sp, 0*FLTS
+    FSARG   $fa1, $sp, 1*FLTS
+    FSARG   $fa2, $sp, 2*FLTS
+    FSARG   $fa3, $sp, 3*FLTS
+    FSARG   $fa4, $sp, 4*FLTS
+    FSARG   $fa5, $sp, 5*FLTS
+    FSARG   $fa6, $sp, 6*FLTS
+    FSARG   $fa7, $sp, 7*FLTS
+#endif
+
+    SARG    $a0, $sp, 8*FLTS+0*PTRS
+    SARG    $a1, $sp, 8*FLTS+1*PTRS
+    SARG    $a2, $sp, 8*FLTS+2*PTRS
+    SARG    $a3, $sp, 8*FLTS+3*PTRS
+    SARG    $a4, $sp, 8*FLTS+4*PTRS
+    SARG    $a5, $sp, 8*FLTS+5*PTRS
+    SARG    $a6, $sp, 8*FLTS+6*PTRS
+    SARG    $a7, $sp, 8*FLTS+7*PTRS
+
+    /* enter C */
+    LARG    $a0, $t1, 1*PTRS
+    LARG    $a1, $t1, 2*PTRS
+    ADDI    $a2, $t1, 0
+    ADDI    $a3, $sp, FRAME_LEN
+    ADDI    $a4, $sp, 0
+
+    bl      ffi_closure_inner
+
+    /* return values */
+#if FLTS
+    FLARG   $fa0, $sp, 0*FLTS
+    FLARG   $fa1, $sp, 1*FLTS
+#endif
+
+    LARG    $a0, $sp, 8*FLTS+0*PTRS
+    LARG    $a1, $sp, 8*FLTS+1*PTRS
+
+    /* restore and return */
+    LARG    $ra, $sp, FRAME_LEN-1*PTRS
+    .cfi_restore 1
+    LARG    $fp, $sp, FRAME_LEN-2*PTRS
+    .cfi_restore 22
+    ADDI    $sp, $sp, FRAME_LEN
+    .cfi_def_cfa_offset 0
+    jirl    $zero, $ra, 0
+    .cfi_endproc
+    .size ffi_go_closure_asm, .-ffi_go_closure_asm


### PR DESCRIPTION
Tested on 3A5000, `make check` and Python cffi module tests passed.

The code is forked from RISC-V port and edited for LoongArch.